### PR TITLE
Add admin table to mongodb and test with postman

### DIFF
--- a/my-app/backend/controllers/adminController.js
+++ b/my-app/backend/controllers/adminController.js
@@ -1,0 +1,100 @@
+import Admin from '../models/Admin.js';
+
+// Create a new admin
+export const createAdmin = async (req, res) => {
+  try {
+    const newAdmin = new Admin(req.body);
+    await newAdmin.save();
+    res.status(201).json({ message: 'Admin created successfully!', admin: newAdmin });
+  } catch (error) {
+    res.status(400).json({ message: 'Error creating admin', error: error.message });
+  }
+};
+
+// Read all admins
+export const getAllAdmins = async (req, res) => {
+  try {
+    const admins = await Admin.find().select('-moderationHistory'); // Exclude long history logs by default
+    res.status(200).json(admins);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving admins', error: error.message });
+  }
+};
+
+// Read a single admin by ID
+export const getAdminById = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const admin = await Admin.findById(id).populate('createdBy', 'name email'); // Populate createdBy to see which admin created this account
+    
+    if (!admin) {
+      return res.status(404).json({ message: 'Admin not found.' });
+    }
+    
+    res.status(200).json(admin);
+  } catch (error) {
+    res.status(500).json({ message: 'Error retrieving admin', error: error.message });
+  }
+};
+
+// Update an admin's details
+export const updateAdmin = async (req, res) => {
+  try {
+    const { id } = req.params;
+    const updates = req.body;
+
+    // Prevent critical auth fields from being changed via this endpoint
+    delete updates.auth;
+    delete updates.email;
+
+    const updatedAdmin = await Admin.findByIdAndUpdate(id, { $set: updates }, { new: true, runValidators: true });
+
+    if (!updatedAdmin) {
+      return res.status(404).json({ message: 'Admin not found.' });
+    }
+
+    res.status(200).json({ message: 'Admin updated successfully!', admin: updatedAdmin });
+  } catch (error) {
+    res.status(400).json({ message: 'Error updating admin', error: error.message });
+  }
+};
+
+// Deactivate an admin (Soft Delete)
+export const deactivateAdmin = async (req, res) => {
+  try {
+    const { id } = req.params;
+    // Instead of deleting, we change their status. This preserves their history.
+    const deactivatedAdmin = await Admin.findByIdAndUpdate(id, { status: 'suspended' }, { new: true });
+
+    if (!deactivatedAdmin) {
+      return res.status(404).json({ message: 'Admin not found.' });
+    }
+
+    res.status(200).json({ message: 'Admin has been suspended.', admin: deactivatedAdmin });
+  } catch (error) {
+    res.status(500).json({ message: 'Error deactivating admin', error: error.message });
+  }
+};
+
+// Add a moderation action to an admin's history
+export const addModerationAction = async (req, res) => {
+  try {
+    const { id } = req.params; // The ID of the admin who performed the action
+    const moderationAction = req.body;
+
+    const updatedAdmin = await Admin.findByIdAndUpdate(
+      id,
+      { $push: { moderationHistory: moderationAction } },
+      { new: true, runValidators: true }
+    );
+
+     if (!updatedAdmin) {
+      return res.status(404).json({ message: 'Admin not found.' });
+    }
+
+    res.status(200).json({ message: 'Moderation action logged.', admin: updatedAdmin });
+
+  } catch (error) {
+     res.status(400).json({ message: 'Error logging moderation action', error: error.message });
+  }
+};

--- a/my-app/backend/models/Admin.js
+++ b/my-app/backend/models/Admin.js
@@ -1,0 +1,111 @@
+import mongoose from 'mongoose';
+
+// Sub-schema tracks moderation actions taken by an admin.
+const moderationActionSchema = new mongoose.Schema({
+  action: {
+    type: String,
+    required: true,
+    enum: ['suspend_user', 'remove_listing', 'warn_user', 'resolve_report'],
+  },
+  targetId: { // The ID of the user or listing that was moderated (**Might change user and listing schema as well**)
+    type: mongoose.Schema.Types.ObjectId,
+    required: true,
+  },
+  reason: {
+    type: String,
+    required: true,
+    trim: true,
+  },
+  actionDate: {
+    type: Date,
+    default: Date.now,
+  },
+});
+
+const adminSchema = new mongoose.Schema(
+  {
+    // Identity
+    email: {
+      type: String,
+      required: [true, 'Admin email is required.'],
+      unique: true,
+      trim: true,
+      lowercase: true,
+      match: [/^\S+@\S+\.\S+$/, 'Please use a valid email address.'], // Ensures the email format is valid
+    },
+    name: {
+      type: String,
+      trim: true,
+    },
+    phone: {
+      type: String,
+      trim: true,
+    },
+
+    // Authentication
+    auth: {
+      provider: {
+        type: String,
+        required: true,
+        enum: ['firebase', 'sso', 'password'],
+      },
+      uid: { // The unique ID from Firebase or SSO provider
+        type: String,
+        required: true,
+        unique: true,
+      },
+    },
+
+    // Admin access
+    role: {
+      type: String,
+      required: true,
+      enum: ['superadmin', 'moderator', 'support'], // (**Can be changed later**)
+      default: 'support',
+    },
+    status: {
+      type: String,
+      required: true,
+      enum: ['active', 'suspended', 'invited'],
+      default: 'invited',
+    },
+    permissions: {
+      type: [String],
+      enum: [ // (**This enum list can be expanded**)
+        'items.read', 'items.write', 'items.moderate',
+        'users.read', 'users.write',
+        'admins.read', 'admins.write',
+        'reports.read', 'reports.write',
+      ],
+      default: [],
+    },
+
+    // Security
+    twoFactorEnabled: {
+      type: Boolean,
+      default: false,
+    },
+    lastLoginAt: {
+      type: Date,
+    },
+    
+    // Auditing history
+    moderationHistory: [moderationActionSchema], // This is an array of actions this admin has taken.
+
+    notes: {
+      type: String,
+      trim: true,
+    },
+    createdBy: { // Reference to the admin who created this account
+      type: mongoose.Schema.Types.ObjectId,
+      ref: 'Admin',
+    },
+  },
+  {
+    timestamps: true,
+  }
+);
+
+const Admin = mongoose.model('Admin', adminSchema, 'admins');
+
+export default Admin;

--- a/my-app/backend/routes/adminRoutes.js
+++ b/my-app/backend/routes/adminRoutes.js
@@ -1,0 +1,28 @@
+import express from 'express';
+import { 
+  createAdmin, 
+  getAllAdmins, 
+  getAdminById, 
+  updateAdmin, 
+  deactivateAdmin,
+  addModerationAction
+} from '../controllers/adminController.js';
+
+const router = express.Router();
+
+// Route for getting all admins and creating a new admin
+router.route('/')
+  .get(getAllAdmins)
+  .post(createAdmin);
+
+// Routes for getting, updating, and deactivating a specific admin
+router.route('/:id')
+  .get(getAdminById)
+  .patch(updateAdmin)       // Use Patch for partial updates
+  .delete(deactivateAdmin); // Use Delete for deactivation (soft delete)
+
+// Route for adding a moderation action to an admin's history
+router.route('/:id/moderation')
+  .post(addModerationAction);
+
+export default router;

--- a/my-app/backend/server.js
+++ b/my-app/backend/server.js
@@ -12,6 +12,7 @@ import messageRoutes from './routes/message.js';
 import fileUpload from './routes/fileUpload.js'; 
 import bodyParser from 'body-parser';
 import stripePackage from 'stripe';
+import adminRoutes from './routes/adminRoutes.js'; // import the admin routes
 
 const app = express();
 if (process.env.NODE_ENV === 'production') {
@@ -56,6 +57,7 @@ app.use('/api/users', userRoutes); // Use the new user routes
 app.use('/api/message', messageRoutes); // Use the new message routes
 app.use('/api/fileUpload', fileUpload);
 // app.use('/file', fileUpload);
+app.use('/api/admins', adminRoutes);
 
 
 // Creating the server (http) const


### PR DESCRIPTION
I added the admin table in mongodb and test the function locally in postman. There are a few questions that might need to deal with later on in discussion. I will list a few below:
1. There is no id that associate with user and listing for now which i think will be beneficial to add them. So there might be a need to change user and listing schema as well.
2. Current admin roles and permission type can be further discussed and modified in the future.
3. I put all features i think will be useful in the admin schema, so if you feels like some parts needed to be deleted and added, just let me know. And since I am currently trying to familiar with the whole database, there might be a discrepancy or conflict between  admin schema and other schema (e.g. user and listing id is one of them, so we will either add id to these schemas or delete id in admin schema.)